### PR TITLE
pass style from props to wrapping div

### DIFF
--- a/src/LazyHero.js
+++ b/src/LazyHero.js
@@ -168,7 +168,7 @@ class LazyHero extends Component {
                     isCentered={this.props.isCentered}
                     opacity={this.props.opacity}
                 >
-                    {this.props.children && <div>{this.props.children}</div>}
+                    {this.props.children && <div style={this.props.style}>{this.props.children}</div>}
                 </Overlay>
             </Root>
         );

--- a/src/LazyHero.js
+++ b/src/LazyHero.js
@@ -168,7 +168,14 @@ class LazyHero extends Component {
                     isCentered={this.props.isCentered}
                     opacity={this.props.opacity}
                 >
-                    {this.props.children && <div style={this.props.style}>{this.props.children}</div>}
+                    {
+                        this.props.children &&
+                            <div
+                                style={this.props.style}
+                            >
+                                {this.props.children}
+                            </div>
+                    }
                 </Overlay>
             </Root>
         );


### PR DESCRIPTION
Hello, 
thanks for this composant !
Actually, we can't add style to wrapping div, and this is a problem when using flexbox. (eg: add `flex: 1` to div).
With this PR we could pass `style={whatever}` to this div
thks